### PR TITLE
Bump version release

### DIFF
--- a/dahdi-tools.spec
+++ b/dahdi-tools.spec
@@ -1,7 +1,7 @@
 Summary: The DAHDI project
 Name: dahdi-tools
 Version: 2.11.1
-Release: 1%{dist}
+Release: 2%{dist}
 License: GPL
 Group: Utilities/System
 Source0: https://downloads.asterisk.org/pub/telephony/dahdi-tools/dahdi-tools-%{version}.tar.gz
@@ -136,13 +136,16 @@ cd $RPM_BUILD_DIR
 %defattr(-,root,root,-)
 %doc LICENSE LICENSE.LGPL
 %{_libdir}/*.so.*
+%{_libdir}/*.so
 
 %files devel
 %defattr(-,root,root,-)
 %doc LICENSE LICENSE.LGPL
 %{_includedir}/*
-%{_libdir}/*.so
 
 %changelog
+* Fri Nov 10 2017 Stefano Fancello <stefano.fancello@nethesis.it> - 2.11.1-2
+- Bump version
+
 * Tue May 09 2017 Stefano Fancello <stefano.fancello@nethesis.it> - 2.11.1-1
 - First NethServer package

--- a/dahdi-tools.spec
+++ b/dahdi-tools.spec
@@ -47,6 +47,23 @@ Requires: libtonezone = %{version}-%{release}
 %description -n libtonezone-devel
 The static libraries and header files needed for building additional plugins/modules
 
+%package        libs
+Summary:        Library files for DAHDI
+Group:          Development/Libraries
+Conflicts:      zaptel-lib
+
+%description    libs
+The dahdi-tools-libs package contains libraries for accessing DAHDI hardware.
+
+%package        devel
+Summary:        Development files for DAHDI
+Group:          Development/Libraries
+Requires:       dahdi-tools-libs%{?_isa} = %{version}-%{release}
+
+%description    devel
+The dahdi-devel package contains libraries and header files for
+developing applications that use DAHDI hardware.
+
 %prep
 %setup -n %{name}-%{version}
 %patch0
@@ -114,3 +131,14 @@ cd $RPM_BUILD_DIR
 %defattr(-, root, root)
 %{_includedir}/dahdi/tonezone.h
 %{_libdir}/libtonezone.a
+
+%files libs
+%defattr(-,root,root,-)
+%doc LICENSE LICENSE.LGPL
+%{_libdir}/*.so.*
+
+%files devel
+%defattr(-,root,root,-)
+%doc LICENSE LICENSE.LGPL
+%{_includedir}/*
+%{_libdir}/*.so

--- a/dahdi-tools.spec
+++ b/dahdi-tools.spec
@@ -142,3 +142,7 @@ cd $RPM_BUILD_DIR
 %doc LICENSE LICENSE.LGPL
 %{_includedir}/*
 %{_libdir}/*.so
+
+%changelog
+* Tue May 09 2017 Stefano Fancello <stefano.fancello@nethesis.it> - 2.11.1-1
+- First NethServer package


### PR DESCRIPTION
- Fix .spec splitting package. Already in released RPM but changes were not committed
- Fix .spec changelog
- Bump version to instal this package instead of Sangoma release